### PR TITLE
🗑  Remove supertest-as-promised

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
         "sinon": "6.1.0",
         "sinon-chai": "3.2.0",
         "supertest": "3.1.0",
-        "supertest-as-promised": "4.0.2",
         "pr-log": "3.0.0"
     },
     "scripts": {

--- a/test/functional/healthcheckMiddlewareSpec.js
+++ b/test/functional/healthcheckMiddlewareSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var supertest = require('supertest-as-promised'),
+var supertest = require('supertest'),
     express = require('express'),
     server = express(),
     healthcheckMiddleware = require('../../lib/healthcheckMiddleware')();


### PR DESCRIPTION
This is not needed anymore since supertest supports promises directly.